### PR TITLE
Added compatibility with Log based loggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ rust_decimal_macros = "1.4.1"
 immutable-map = "0.1.2"
 num-traits = "0.2.11"
 locations = {git = "https://github.com/gjf2a/locations"}
+fern = "0.6.0"
+log = "0.4.11"
+chrono = "0.4.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,7 @@ impl <S,O,G,M> PlannerStep<S,O,M>
 
     fn verb(&self, level: usize, text: String) {
         if self.verbose > level {
-            info!("{}", text);
+            debug!("{}", text); //This should be set to debug, not info, as to not spam the log with tasks on verbosity level 2.
         }
     }
 }


### PR DESCRIPTION
This commits support for loggers based on the [Log](https://docs.rs/log/0.4.11/log/) library, such as Fern and Lib4Rs. In order to set up a logger, you set it up in the main method in your expr library. This allows us to get pretty formatted output, and filtering of output based on output level, and chaining to both stdout and file output easily.

This helps mitigate the issues I was having with debugging pfile4 by having clean and easy to read output. 

For example, here is an example of an output file with these proposed changes. 

[output.log](https://github.com/gjf2a/anyhop/files/4950259/output.log)

In order to use this, you have to set up a logger in your program before calling process_expr_cmd_line(). In satellite_numeric_expr, I used [Fern](https://docs.rs/fern/0.6.0/fern/).